### PR TITLE
Changes to Support ECK 1.1.2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0.1"
+appVersion: "1.1.2"
 description: Helm chart to deploy the Elastic operator (ECK / Elastic Cloud on Kubernetes)
 name: elastic-operator
-version: 0.2.0
+version: 0.2.1

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Elastic Cloud on Kubernetes Helm chart
 
+[ECK Operator Helm chart on Github](https://github.com/collibra/elastic-operator)
+
 Helm chart to deploy [ECK operator](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-overview.html).
 
-This chart is based on the official Elastic [resource file](https://download.elastic.co/downloads/eck/1.0.1/all-in-one.yaml).
+This chart is based on the official Elastic [resource file](https://download.elastic.co/downloads/eck/1.1.2/all-in-one.yaml).
 
 __DISCLAIMER__: This Helm chart is provided as-is and is an alpha version.
 

--- a/crds/apmservers.yaml
+++ b/crds/apmservers.yaml
@@ -1,8 +1,10 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
-  name: kibanas.kibana.k8s.elastic.co
+  name: apmservers.apm.k8s.elastic.co
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.health
@@ -13,28 +15,28 @@ spec:
     name: nodes
     type: integer
   - JSONPath: .spec.version
-    description: Kibana version
+    description: APM version
     name: version
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: age
     type: date
-  group: kibana.k8s.elastic.co
+  group: apm.k8s.elastic.co
   names:
     categories:
     - elastic
-    kind: Kibana
-    listKind: KibanaList
-    plural: kibanas
+    kind: ApmServer
+    listKind: ApmServerList
+    plural: apmservers
     shortNames:
-    - kb
-    singular: kibana
+    - apm
+    singular: apmserver
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
-      description: Kibana represents a Kibana resource in a Kubernetes cluster.
+      description: ApmServer represents an APM Server resource in a Kubernetes cluster.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -49,18 +51,18 @@ spec:
         metadata:
           type: object
         spec:
-          description: KibanaSpec holds the specification of a Kibana instance.
+          description: ApmServerSpec holds the specification of an APM Server.
           properties:
             config:
-              description: 'Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html'
+              description: 'Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html'
               type: object
             count:
-              description: Count of Kibana instances to deploy.
+              description: Count of APM Server instances to deploy.
               format: int32
               type: integer
             elasticsearchRef:
-              description: ElasticsearchRef is a reference to an Elasticsearch cluster
-                running in the same Kubernetes cluster.
+              description: ElasticsearchRef is a reference to the output Elasticsearch
+                cluster running in the same Kubernetes cluster.
               properties:
                 name:
                   description: Name of the Kubernetes object.
@@ -73,7 +75,8 @@ spec:
               - name
               type: object
             http:
-              description: HTTP holds the HTTP layer configuration for Kibana.
+              description: HTTP holds the HTTP layer configuration for the APM Server
+                resource.
               properties:
                 service:
                   description: Service defines the template for the associated Kubernetes
@@ -203,8 +206,8 @@ spec:
                                 type: string
                               targetPort:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: 'Number or name of the port to access
                                   on the pods targeted by the service. Number must
                                   be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
@@ -261,6 +264,24 @@ spec:
                                   type: integer
                               type: object
                           type: object
+                        topologyKeys:
+                          description: topologyKeys is a preference-order list of
+                            topology keys which implementations of services should
+                            use to preferentially sort endpoints when accessing this
+                            Service, it can not be used at the same time as externalTrafficPolicy=Local.
+                            Topology keys must be valid label keys and at most 16
+                            keys may be specified. Endpoints are chosen based on the
+                            first topology key with available backends. If this field
+                            is specified and all entries have no backends that match
+                            the topology of the client, the service has no backends
+                            for that client and connections should fail. The special
+                            value "*" may be used to mean "any topology". This catch-all
+                            value, if used, only makes sense as the last value in
+                            the list. If this is not specified or empty, no topology
+                            constraints will be applied.
+                          items:
+                            type: string
+                          type: array
                         type:
                           description: 'type determines how the Service is exposed.
                             Defaults to ClusterIP. Valid options are ExternalName,
@@ -321,15 +342,15 @@ spec:
                   type: object
               type: object
             image:
-              description: Image is the Kibana Docker image to deploy.
+              description: Image is the APM Server Docker image to deploy.
               type: string
             podTemplate:
               description: PodTemplate provides customisation options (labels, annotations,
-                affinity rules, resource requests, and so on) for the Kibana pods
+                affinity rules, resource requests, and so on) for the APM Server pods.
               type: object
             secureSettings:
-              description: 'SecureSettings is a list of references to Kubernetes secrets
-                containing sensitive configuration options for Kibana. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-kibana.html#k8s-kibana-secure-settings'
+              description: SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for APM Server.
               items:
                 description: SecretSource defines a data source based on a Kubernetes
                   Secret.
@@ -363,21 +384,38 @@ spec:
                 - secretName
                 type: object
               type: array
-            version:
-              description: Version of Kibana.
+            serviceAccountName:
+              description: ServiceAccountName is used to check access from the current
+                resource to a resource (eg. Elasticsearch) in a different namespace.
+                Can only be used if ECK is enforcing RBAC on references.
               type: string
+            version:
+              description: Version of the APM Server.
+              type: string
+          required:
+          - version
           type: object
         status:
-          description: KibanaStatus defines the observed state of Kibana
+          description: ApmServerStatus defines the observed state of ApmServer
           properties:
             associationStatus:
-              description: AssociationStatus is the status of an association resource.
+              description: Association is the status of any auto-linking to Elasticsearch
+                clusters.
               type: string
             availableNodes:
               format: int32
               type: integer
             health:
-              description: KibanaHealth expresses the status of the Kibana instances.
+              description: ApmServerHealth expresses the status of the Apm Server
+                instances.
+              type: string
+            secretTokenSecret:
+              description: SecretTokenSecretName is the name of the Secret that contains
+                the secret token
+              type: string
+            service:
+              description: ExternalService is the name of the service the agents should
+                connect to.
               type: string
           type: object
   version: v1

--- a/crds/elasticsearch.yaml
+++ b/crds/elasticsearch.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
@@ -56,6 +58,33 @@ spec:
           description: ElasticsearchSpec holds the specification of an Elasticsearch
             cluster.
           properties:
+            auth:
+              description: Auth contains user authentication and authorization security
+                settings for Elasticsearch.
+              properties:
+                fileRealm:
+                  description: FileRealm to propagate to the Elasticsearch cluster.
+                  items:
+                    description: FileRealmSource references users to create in the
+                      Elasticsearch cluster.
+                    properties:
+                      secretName:
+                        description: SecretName is the name of the secret.
+                        type: string
+                    type: object
+                  type: array
+                roles:
+                  description: Roles to propagate to the Elasticsearch cluster.
+                  items:
+                    description: RoleSource references roles to create in the Elasticsearch
+                      cluster.
+                    properties:
+                      secretName:
+                        description: SecretName is the name of the secret.
+                        type: string
+                    type: object
+                  type: array
+              type: object
             http:
               description: HTTP holds HTTP layer settings for Elasticsearch.
               properties:
@@ -187,8 +216,8 @@ spec:
                                 type: string
                               targetPort:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: 'Number or name of the port to access
                                   on the pods targeted by the service. Number must
                                   be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
@@ -245,6 +274,24 @@ spec:
                                   type: integer
                               type: object
                           type: object
+                        topologyKeys:
+                          description: topologyKeys is a preference-order list of
+                            topology keys which implementations of services should
+                            use to preferentially sort endpoints when accessing this
+                            Service, it can not be used at the same time as externalTrafficPolicy=Local.
+                            Topology keys must be valid label keys and at most 16
+                            keys may be specified. Endpoints are chosen based on the
+                            first topology key with available backends. If this field
+                            is specified and all entries have no backends that match
+                            the topology of the client, the service has no backends
+                            for that client and connections should fail. The special
+                            value "*" may be used to mean "any topology". This catch-all
+                            value, if used, only makes sense as the last value in
+                            the list. If this is not specified or empty, no topology
+                            constraints will be applied.
+                          items:
+                            type: string
+                          type: array
                         type:
                           description: 'type determines how the Service is exposed.
                             Defaults to ClusterIP. Valid options are ExternalName,
@@ -405,13 +452,19 @@ spec:
                               properties:
                                 limits:
                                   additionalProperties:
-                                    type: string
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   description: 'Limits describes the maximum amount
                                     of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                                 requests:
                                   additionalProperties:
-                                    type: string
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   description: 'Requests describes the minimum amount
                                     of compute resources required. If Requests is
                                     omitted for a container, it defaults to Limits
@@ -492,7 +545,10 @@ spec:
                               type: array
                             capacity:
                               additionalProperties:
-                                type: string
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               description: Represents the actual resources of the
                                 underlying volume.
                               type: object
@@ -562,8 +618,8 @@ spec:
                   properties:
                     maxUnavailable:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: An eviction is allowed if at most "maxUnavailable"
                         pods selected by "selector" are unavailable after the eviction,
                         i.e. even in absence of the evicted pod. For example, one
@@ -571,8 +627,8 @@ spec:
                         is a mutually exclusive setting with "minAvailable".
                     minAvailable:
                       anyOf:
-                      - type: string
                       - type: integer
+                      - type: string
                       description: An eviction is allowed if at least "minAvailable"
                         pods selected by "selector" will still be available after
                         the eviction, i.e. even in the absence of the evicted pod.  So
@@ -625,10 +681,40 @@ spec:
                       type: object
                   type: object
               type: object
+            remoteClusters:
+              description: RemoteClusters enables you to establish uni-directional
+                connections to a remote Elasticsearch cluster.
+              items:
+                description: RemoteCluster declares a remote Elasticsearch cluster
+                  connection.
+                properties:
+                  elasticsearchRef:
+                    description: ElasticsearchRef is a reference to an Elasticsearch
+                      cluster running within the same k8s cluster.
+                    properties:
+                      name:
+                        description: Name of the Kubernetes object.
+                        type: string
+                      namespace:
+                        description: Namespace of the Kubernetes object. If empty,
+                          defaults to the current namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  name:
+                    description: Name is the name of the remote cluster as it is set
+                      in the Elasticsearch settings. The name is expected to be unique
+                      for each remote clusters.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
             secureSettings:
-              description: 'SecureSettings is a list of references to Kubernetes secrets
-                containing sensitive configuration options for Elasticsearch. See:
-                https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-es-secure-settings.html'
+              description: SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for Elasticsearch.
               items:
                 description: SecretSource defines a data source based on a Kubernetes
                   Secret.
@@ -649,7 +735,7 @@ spec:
                         path:
                           description: Path is the relative file path to map the key
                             to. Path must not be an absolute file path and must not
-                            contain any "elastic-cloud-on-k8s." components.
+                            contain any ".." components.
                           type: string
                       required:
                       - key
@@ -662,6 +748,237 @@ spec:
                 - secretName
                 type: object
               type: array
+            serviceAccountName:
+              description: ServiceAccountName is used to check access from the current
+                resource to a resource (eg. a remote Elasticsearch cluster) in a different
+                namespace. Can only be used if ECK is enforcing RBAC on references.
+              type: string
+            transport:
+              description: Transport holds transport layer settings for Elasticsearch.
+              properties:
+                service:
+                  description: Service defines the template for the associated Kubernetes
+                    Service object.
+                  properties:
+                    metadata:
+                      description: ObjectMeta is the metadata of the service. The
+                        name and namespace provided here are managed by ECK and will
+                        be ignored.
+                      type: object
+                    spec:
+                      description: Spec is the specification of the service.
+                      properties:
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly by the master. If an
+                            address is specified manually and is not in use by others,
+                            it will be allocated to the service; otherwise, creation
+                            of the service will fail. This field can not be changed
+                            through updates. Valid values are "None", empty string
+                            (""), or a valid IP address. "None" can be specified for
+                            headless services when proxying is not required. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            kubedns or equivalent will return as a CNAME record for
+                            this service. No proxying will be involved. Must be a
+                            valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires Type to be ExternalName.
+                          type: string
+                        externalTrafficPolicy:
+                          description: externalTrafficPolicy denotes if this Service
+                            desires to route external traffic to node-local or cluster-wide
+                            endpoints. "Local" preserves the client source IP and
+                            avoids a second hop for LoadBalancer and Nodeport type
+                            services, but risks potentially imbalanced traffic spreading.
+                            "Cluster" obscures the client source IP and may cause
+                            a second hop to another node, but should have good overall
+                            load-spreading.
+                          type: string
+                        healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. If not specified, HealthCheckNodePort
+                            is created by the service api backend with the allocated
+                            nodePort. Will use user-specified nodePort value if specified
+                            by the client. Only effects when Type is set to LoadBalancer
+                            and ExternalTrafficPolicy is set to Local.
+                          format: int32
+                          type: integer
+                        ipFamily:
+                          description: ipFamily specifies whether this Service has
+                            a preference for a particular IP family (e.g. IPv4 vs.
+                            IPv6).  If a specific IP family is requested, the clusterIP
+                            field will be allocated from that family, if it is available
+                            in the cluster.  If no IP family is requested, the cluster's
+                            primary IP family will be used. Other IP fields (loadBalancerIP,
+                            loadBalancerSourceRanges, externalIPs) and controllers
+                            which allocate external load-balancers should use the
+                            same IP family.  Endpoints for this Service will be of
+                            this family.  This field is immutable after creation.
+                            Assigning a ServiceIPFamily not available in the cluster
+                            (e.g. IPv6 in IPv4 only cluster) is an error condition
+                            and will fail during clusterIP assignment.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer
+                            LoadBalancer will get created with the IP specified in
+                            this field. This feature depends on whether the underlying
+                            cloud-provider supports specifying the loadBalancerIP
+                            when a load balancer is created. This field will be ignored
+                            if the cloud-provider does not support the feature.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          items:
+                            type: string
+                          type: array
+                        ports:
+                          description: 'The list of ports that are exposed by this
+                            service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          items:
+                            description: ServicePort contains information on service's
+                              port.
+                            properties:
+                              name:
+                                description: The name of this port within the service.
+                                  This must be a DNS_LABEL. All ports within a ServiceSpec
+                                  must have unique names. When considering the endpoints
+                                  for a Service, this must match the 'name' field
+                                  in the EndpointPort. Optional if only one ServicePort
+                                  is defined on this service.
+                                type: string
+                              nodePort:
+                                description: 'The port on each node on which this
+                                  service is exposed when type=NodePort or LoadBalancer.
+                                  Usually assigned by the system. If specified, it
+                                  will be allocated to the service if unused or else
+                                  creation of the service will fail. Default is to
+                                  auto-allocate a port if the ServiceType of this
+                                  Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                format: int32
+                                type: integer
+                              port:
+                                description: The port that will be exposed by this
+                                  service.
+                                format: int32
+                                type: integer
+                              protocol:
+                                description: The IP protocol for this port. Supports
+                                  "TCP", "UDP", and "SCTP". Default is TCP.
+                                type: string
+                              targetPort:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'Number or name of the port to access
+                                  on the pods targeted by the service. Number must
+                                  be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  If this is a string, it will be looked up as a named
+                                  port in the target Pod''s container ports. If this
+                                  is not specified, the value of the ''port'' field
+                                  is used (an identity map). This field is ignored
+                                  for services with clusterIP=None, and should be
+                                  omitted or set equal to the ''port'' field. More
+                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                            required:
+                            - port
+                            type: object
+                          type: array
+                        publishNotReadyAddresses:
+                          description: publishNotReadyAddresses, when set to true,
+                            indicates that DNS implementations must publish the notReadyAddresses
+                            of subsets for the Endpoints associated with the Service.
+                            The default value is false. The primary use case for setting
+                            this field is to use a StatefulSet's Headless Service
+                            to propagate SRV records for its Pods without respect
+                            to their readiness for purpose of peer discovery.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                          type: object
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        topologyKeys:
+                          description: topologyKeys is a preference-order list of
+                            topology keys which implementations of services should
+                            use to preferentially sort endpoints when accessing this
+                            Service, it can not be used at the same time as externalTrafficPolicy=Local.
+                            Topology keys must be valid label keys and at most 16
+                            keys may be specified. Endpoints are chosen based on the
+                            first topology key with available backends. If this field
+                            is specified and all entries have no backends that match
+                            the topology of the client, the service has no backends
+                            for that client and connections should fail. The special
+                            value "*" may be used to mean "any topology". This catch-all
+                            value, if used, only makes sense as the last value in
+                            the list. If this is not specified or empty, no topology
+                            constraints will be applied.
+                          items:
+                            type: string
+                          type: array
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ExternalName"
+                            maps to the specified externalName. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object. If clusterIP is "None", no virtual IP is allocated
+                            and the endpoints are published as a set of endpoints
+                            rather than a stable IP. "NodePort" builds on ClusterIP
+                            and allocates a port on every node which routes to the
+                            clusterIP. "LoadBalancer" builds on NodePort and creates
+                            an external load-balancer (if supported in the current
+                            cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      type: object
+                  type: object
+              type: object
             updateStrategy:
               description: UpdateStrategy specifies how updates to the cluster should
                 be performed.
@@ -692,6 +1009,7 @@ spec:
               type: string
           required:
           - nodeSets
+          - version
           type: object
         status:
           description: ElasticsearchStatus defines the observed state of Elasticsearch

--- a/crds/kibana.yaml
+++ b/crds/kibana.yaml
@@ -1,8 +1,10 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
-  name: apmservers.apm.k8s.elastic.co
+  name: kibanas.kibana.k8s.elastic.co
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.health
@@ -13,28 +15,28 @@ spec:
     name: nodes
     type: integer
   - JSONPath: .spec.version
-    description: APM version
+    description: Kibana version
     name: version
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: age
     type: date
-  group: apm.k8s.elastic.co
+  group: kibana.k8s.elastic.co
   names:
     categories:
     - elastic
-    kind: ApmServer
-    listKind: ApmServerList
-    plural: apmservers
+    kind: Kibana
+    listKind: KibanaList
+    plural: kibanas
     shortNames:
-    - apm
-    singular: apmserver
+    - kb
+    singular: kibana
   scope: Namespaced
   subresources:
     status: {}
   validation:
     openAPIV3Schema:
-      description: ApmServer represents an APM Server resource in a Kubernetes cluster.
+      description: Kibana represents a Kibana resource in a Kubernetes cluster.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -49,18 +51,18 @@ spec:
         metadata:
           type: object
         spec:
-          description: ApmServerSpec holds the specification of an APM Server.
+          description: KibanaSpec holds the specification of a Kibana instance.
           properties:
             config:
-              description: 'Config holds the APM Server configuration. See: https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html'
+              description: 'Config holds the Kibana configuration. See: https://www.elastic.co/guide/en/kibana/current/settings.html'
               type: object
             count:
-              description: Count of APM Server instances to deploy.
+              description: Count of Kibana instances to deploy.
               format: int32
               type: integer
             elasticsearchRef:
-              description: ElasticsearchRef is a reference to the output Elasticsearch
-                cluster running in the same Kubernetes cluster.
+              description: ElasticsearchRef is a reference to an Elasticsearch cluster
+                running in the same Kubernetes cluster.
               properties:
                 name:
                   description: Name of the Kubernetes object.
@@ -73,8 +75,7 @@ spec:
               - name
               type: object
             http:
-              description: HTTP holds the HTTP layer configuration for the APM Server
-                resource.
+              description: HTTP holds the HTTP layer configuration for Kibana.
               properties:
                 service:
                   description: Service defines the template for the associated Kubernetes
@@ -204,8 +205,8 @@ spec:
                                 type: string
                               targetPort:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: 'Number or name of the port to access
                                   on the pods targeted by the service. Number must
                                   be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
@@ -262,6 +263,24 @@ spec:
                                   type: integer
                               type: object
                           type: object
+                        topologyKeys:
+                          description: topologyKeys is a preference-order list of
+                            topology keys which implementations of services should
+                            use to preferentially sort endpoints when accessing this
+                            Service, it can not be used at the same time as externalTrafficPolicy=Local.
+                            Topology keys must be valid label keys and at most 16
+                            keys may be specified. Endpoints are chosen based on the
+                            first topology key with available backends. If this field
+                            is specified and all entries have no backends that match
+                            the topology of the client, the service has no backends
+                            for that client and connections should fail. The special
+                            value "*" may be used to mean "any topology". This catch-all
+                            value, if used, only makes sense as the last value in
+                            the list. If this is not specified or empty, no topology
+                            constraints will be applied.
+                          items:
+                            type: string
+                          type: array
                         type:
                           description: 'type determines how the Service is exposed.
                             Defaults to ClusterIP. Valid options are ExternalName,
@@ -322,15 +341,15 @@ spec:
                   type: object
               type: object
             image:
-              description: Image is the APM Server Docker image to deploy.
+              description: Image is the Kibana Docker image to deploy.
               type: string
             podTemplate:
               description: PodTemplate provides customisation options (labels, annotations,
-                affinity rules, resource requests, and so on) for the APM Server pods.
+                affinity rules, resource requests, and so on) for the Kibana pods
               type: object
             secureSettings:
-              description: 'SecureSettings is a list of references to Kubernetes secrets
-                containing sensitive configuration options for APM Server. See: https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-apm-server.html#k8s-apm-secure-settings'
+              description: SecureSettings is a list of references to Kubernetes secrets
+                containing sensitive configuration options for Kibana.
               items:
                 description: SecretSource defines a data source based on a Kubernetes
                   Secret.
@@ -364,31 +383,28 @@ spec:
                 - secretName
                 type: object
               type: array
-            version:
-              description: Version of the APM Server.
+            serviceAccountName:
+              description: ServiceAccountName is used to check access from the current
+                resource to a resource (eg. Elasticsearch) in a different namespace.
+                Can only be used if ECK is enforcing RBAC on references.
               type: string
+            version:
+              description: Version of Kibana.
+              type: string
+          required:
+          - version
           type: object
         status:
-          description: ApmServerStatus defines the observed state of ApmServer
+          description: KibanaStatus defines the observed state of Kibana
           properties:
             associationStatus:
-              description: Association is the status of any auto-linking to Elasticsearch
-                clusters.
+              description: AssociationStatus is the status of an association resource.
               type: string
             availableNodes:
               format: int32
               type: integer
             health:
-              description: ApmServerHealth expresses the status of the Apm Server
-                instances.
-              type: string
-            secretTokenSecret:
-              description: SecretTokenSecretName is the name of the Secret that contains
-                the secret token
-              type: string
-            service:
-              description: ExternalService is the name of the service the agents should
-                connect to.
+              description: KibanaHealth expresses the status of the Kibana instances.
               type: string
           type: object
   version: v1

--- a/templates/rbac/clusterrole.yaml
+++ b/templates/rbac/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{ if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -6,6 +6,12 @@ metadata:
   labels:
 {{ include "elastic-operator.labels" . | indent 4 }}
 rules:
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 - apiGroups:
   - ""
   resources:
@@ -93,19 +99,6 @@ rules:
   - update
   - patch
   - delete
-- apiGroups:
-  - associations.k8s.elastic.co
-  resources:
-  - apmserverelasticsearchassociations
-  - apmserverelasticsearchassociations/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
 {{- if .Values.webhook.enabled }}
 - apiGroups:
   - admissionregistration.k8s.io
@@ -121,4 +114,43 @@ rules:
   - patch
   - delete
 {{- end }}
-{{- end -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "elastic-operator.serviceAccountName" . }}-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+{{ include "elastic-operator.labels" . | indent 4 }}
+rules:
+  - apiGroups: ["elasticsearch.k8s.elastic.co"]
+    resources: ["elasticsearches"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apm.k8s.elastic.co"]
+    resources: ["apmservers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kibana.k8s.elastic.co"]
+    resources: ["kibanas"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "elastic-operator.serviceAccountName" . }}-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+{{ include "elastic-operator.labels" . | indent 4 }}
+rules:
+  - apiGroups: ["elasticsearch.k8s.elastic.co"]
+    resources: ["elasticsearches"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["apm.k8s.elastic.co"]
+    resources: ["apmservers"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["kibana.k8s.elastic.co"]
+    resources: ["kibanas"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -32,8 +32,9 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if .Values.podAnnotations }}
       annotations:
+        "co.elastic.logs/raw": "[{\"type\":\"container\",\"json.keys_under_root\":true,\"paths\":[\"/var/log/containers/*${data.kubernetes.container.id}.log\"],\"processors\":[{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"error\",\"to\":\"_error\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_error\",\"to\":\"error.message\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"source\",\"to\":\"_source\"}]}},{\"convert\":{\"mode\":\"rename\",\"ignore_missing\":true,\"fields\":[{\"from\":\"_source\",\"to\":\"event.source\"}]}}]}]"
+      {{- if .Values.podAnnotations }}
         {{- with .Values.podAnnotations }}
         {{- range $key, $value := . }}
         {{ $key }}: {{ $value | quote }}

--- a/templates/validatingwebhook.yaml
+++ b/templates/validatingwebhook.yaml
@@ -8,40 +8,112 @@ metadata:
   labels:
 {{ include "elastic-operator.labels" . | indent 4 }}
 webhooks:
-  - clientConfig:
-      caBundle: Cg==
-      service:
-        name: {{ include "elastic-operator.fullname" . }}
-        namespace: {{ .Release.Namespace }}
-        path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
-    failurePolicy: Ignore
-    name: elastic-es-validation-v1.k8s.elastic.co
-    rules:
-      - apiGroups:
-          - elasticsearch.k8s.elastic.co
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - elasticsearches
-  - clientConfig:
-      caBundle: Cg==
-      service:
-        name: {{ include "elastic-operator.fullname" . }}
-        namespace: {{ .Release.Namespace }}
-        path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
-    failurePolicy: Ignore
-    name: elastic-es-validation-v1beta1.k8s.elastic.co
-    rules:
-      - apiGroups:
-          - elasticsearch.k8s.elastic.co
-        apiVersions:
-          - v1beta1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - elasticsearches
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: elastic-webhook-server
+      namespace: elastic-system
+      path: /validate-apm-k8s-elastic-co-v1-apmserver
+  failurePolicy: Ignore
+  name: elastic-apm-validation-v1.k8s.elastic.co
+  rules:
+  - apiGroups:
+    - apm.k8s.elastic.co
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - apmservers
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: elastic-webhook-server
+      namespace: elastic-system
+      path: /validate-apm-k8s-elastic-co-v1beta1-apmserver
+  failurePolicy: Ignore
+  name: elastic-apm-validation-v1beta1.k8s.elastic.co
+  rules:
+  - apiGroups:
+    - apm.k8s.elastic.co
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - apmservers
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: elastic-webhook-server
+      namespace: elastic-system
+      path: /validate-elasticsearch-k8s-elastic-co-v1-elasticsearch
+  failurePolicy: Ignore
+  name: elastic-es-validation-v1.k8s.elastic.co
+  rules:
+  - apiGroups:
+    - elasticsearch.k8s.elastic.co
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - elasticsearches
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: elastic-webhook-server
+      namespace: elastic-system
+      path: /validate-elasticsearch-k8s-elastic-co-v1beta1-elasticsearch
+  failurePolicy: Ignore
+  name: elastic-es-validation-v1beta1.k8s.elastic.co
+  rules:
+  - apiGroups:
+    - elasticsearch.k8s.elastic.co
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - elasticsearches
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: {{ include "elastic-operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-kibana-k8s-elastic-co-v1-kibana
+  failurePolicy: Ignore
+  name: elastic-kb-validation-v1.k8s.elastic.co
+  rules:
+  - apiGroups:
+    - kibana.k8s.elastic.co
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kibanas
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: {{ include "elastic-operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-kibana-k8s-elastic-co-v1beta1-kibana
+  failurePolicy: Ignore
+  name: elastic-kb-validation-v1beta1.k8s.elastic.co
+  rules:
+  - apiGroups:
+    - kibana.k8s.elastic.co
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kibanas
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: docker.elastic.co/eck/eck-operator
-  tag: 1.0.1
+  tag: 1.1.2
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
- Made changes to work with the latest version of ECK, 1.1.2
- moved crds to top level of helm as best practice so they install automatically

Thanks for throwing this together, hopefully Elastic will start to support it in the near future